### PR TITLE
78 dialogue system   modifications for more polished system

### DIFF
--- a/Scripts/Dialogue/DialogueBalloon.cs
+++ b/Scripts/Dialogue/DialogueBalloon.cs
@@ -118,7 +118,31 @@ public partial class DialogueBalloon : CanvasLayer
 
 	public override void _UnhandledInput(InputEvent @event)
 	{
-		// Only the balloon is allowed to handle input while it's showing
+		if (!balloon.Visible)
+			return;
+
+		bool mouseClicked = @event is InputEventMouseButton mouse &&
+		                    mouse.ButtonIndex == MouseButton.Left &&
+		                    mouse.Pressed;
+
+		bool skipPressed = @event.IsActionPressed(SkipAction);
+		bool nextPressed = @event.IsActionPressed(NextAction);
+
+		if ((bool)dialogueLabel.Get("is_typing"))
+		{
+			if (mouseClicked || skipPressed)
+			{
+				dialogueLabel.Call("skip_typing");
+			}
+		}
+		else if (isWaitingForInput && dialogueLine.Responses.Count == 0)
+		{
+			if (mouseClicked || nextPressed)
+			{
+				Next(dialogueLine.NextId);
+			}
+		}
+		
 		GetViewport().SetInputAsHandled();
 	}
 

--- a/project.godot
+++ b/project.godot
@@ -79,7 +79,7 @@ ui_accept={
 ui_cancel={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)
-, Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":1,"position":Vector2(94, 10),"global_position":Vector2(98, 51),"factor":1.0,"button_index":1,"canceled":false,"pressed":true,"double_click":true,"script":null)
+, Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
 ]
 }
 ui_text_completion_accept={


### PR DESCRIPTION
updated _UnhandledInput() (while keeping setinputashandled() to prevent clicks seeping into rest of game) and added additional buttons to skip and accept actions.  Clicking or hitting space bar while mid dialogue and in pause menu only won't progress dialogue but will trigger button in pause menu as intended . Think this covers many bases and leverages the add on. 

